### PR TITLE
feat: handle custom errors

### DIFF
--- a/lib/hs_redis/configuration.rb
+++ b/lib/hs_redis/configuration.rb
@@ -2,6 +2,10 @@ module HsRedis
   class Configuration
     def initialize
       @configuration = OpenStruct.new
+      @configuration.custom_errors = [
+        Redis::ConnectionError,
+        Redis::CommandError
+      ]
     end
 
     def timeout
@@ -53,6 +57,14 @@ module HsRedis
     def registry=(registry)
       @configuration.registry = registry
     end
+
+    def custom_errors
+      @configuration.custom_errors
+    end
+
+    def custom_errors=(errors)
+      @configuration.custom_errors = errors
+    end
   end
 
   def self.configuration
@@ -71,7 +83,7 @@ module HsRedis
     unless HsRedis::Clients::Registry.store_registered?(name)
       HsRedis::Clients::Registry.registered_stores[name.to_sym] = HsRedis::Store.new(name)
     end
-    
+
     HsRedis::Clients::Registry.registered_stores[name.to_sym]
   end
 

--- a/lib/hs_redis/store.rb
+++ b/lib/hs_redis/store.rb
@@ -34,7 +34,7 @@ module HsRedis
           result = CacheEntry.parse(result)
         end
         result
-      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, Redis::ConnectionError, Redis::CommandError => e
+      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, *HsRedis.configuration.custom_errors => e
         logit.error(title: 'hs-redis-error' ,transaction: 'GET', error_details: e.message, stack_trace: e, timeout_setting: timeout, key: key)
         run_callback(callback)
       end
@@ -72,7 +72,7 @@ module HsRedis
           end
         end
         fetched
-      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, Redis::ConnectionError, Redis::CommandError => e
+      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, *HsRedis.configuration.custom_errors => e
         logit.error(title: 'hs-redis-error', transaction: 'MGET', error_details: e.message, stack_trace: e, timeout_setting: timeout )
         run_callback(callback)
       end
@@ -85,7 +85,7 @@ module HsRedis
     def set(key, value, callback, expires_in: HsRedis.configuration.expires_in)
       begin
         write(key, expires_in, value)
-      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, Redis::ConnectionError, Redis::CommandError => e
+      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, *HsRedis.configuration.custom_errors => e
         logit.error(transaction: 'SET', error_details: e.message, stack_trace: e, timeout_setting: timeout, key: key )
         run_callback(callback)
       end
@@ -98,7 +98,7 @@ module HsRedis
         with_timeout do
           client.with { |redis| redis.mapped_mset(hash) }
         end
-      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, Redis::ConnectionError, Redis::CommandError => e
+      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, *HsRedis.configuration.custom_errors => e
         logit.error(transaction: 'MSET', error_details: e.message, stack_trace: e, timeout_setting: timeout, key: hash.keys.join(', ') )
         run_callback(callback)
       end
@@ -124,7 +124,7 @@ module HsRedis
     def delete(key, callback)
       begin
         delete_key(key)
-      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, Redis::ConnectionError, Redis::CommandError => e
+      rescue Redis::TimeoutError, Redis::CannotConnectError, Timeout::Error, *HsRedis.configuration.custom_errors => e
         logit.error(title: 'hs-redis-error', transaction: 'DELETE', error_details: e.message, stack_trace: e, timeout_setting: timeout, key: key )
         run_callback(callback)
       end

--- a/spec/hs_redis/configuration_spec.rb
+++ b/spec/hs_redis/configuration_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 RSpec.describe HsRedis::Configuration do
   let(:configuration) { described_class.new }
 
+  class CustomError < StandardError; end
+
   it 'can set timeout' do
     expected_timeout = 5
     configuration.timeout = expected_timeout
@@ -48,5 +50,10 @@ RSpec.describe HsRedis::Configuration do
 
   it 'can get client' do
     expect(HsRedis.client(:name).is_a? HsRedis::Store).to eq true
+  end
+
+  it 'can set custom errors to rescue' do
+    configuration.custom_errors += [CustomError]
+    expect(configuration.custom_errors).to include(CustomError)
   end
 end


### PR DESCRIPTION
Add ability to register custom errors. These custom errors will be handled. Instead of raise the error, the library will call the callback 
```ruby
HsRedis.configure do |config|
  config.custom_errors += [CustomError]
end
```

This way, we can register additional errors that need to be handled without modifying the `HsRedis` implementation